### PR TITLE
fix: dates output as UTC instead of local timezone

### DIFF
--- a/.esper/phases/001-mvp-crud-and-agent-skill.md
+++ b/.esper/phases/001-mvp-crud-and-agent-skill.md
@@ -62,3 +62,4 @@ Deliver a working Swift CLI that can list calendars, list/create/update/delete e
 - Plan 10 — Attendee management: Add AttendeeInfo model and attendee display in event output. Files: AttendeeInfo.swift, EventInfo.swift, CreateEventCommand.swift
 - Plan 11 — Alert/notification configuration: Add AlarmInfo model, AlertHelper parser, --alert flags. Files: AlarmInfo.swift, AlertHelper.swift, CreateEventCommand.swift, UpdateEventCommand.swift, EventInfo.swift
 - Plan 12 — Homebrew formula & distribution: Add CI/CD workflows and Makefile for release builds. Files: .github/workflows/ci.yml, .github/workflows/release.yml, Makefile
+- Plan 13 — fix: dates output as UTC instead of local timezone: Change the output formatter in EventInfo.swift to use local timezone. Files: EventInfo.swift, DateParserTests.swift

--- a/.esper/plans/active/013-timezone-conversion.md
+++ b/.esper/plans/active/013-timezone-conversion.md
@@ -1,0 +1,52 @@
+---
+id: 13
+title: fix: dates output as UTC instead of local timezone
+status: active
+type: fix
+priority: 1
+phase: 001-mvp-crud-and-agent-skill
+branch: fix/timezone-conversion
+created: 2026-02-22
+gh_issue: 3
+---
+# fix: dates output as UTC instead of local timezone
+
+## Context
+
+EventInfo.swift uses `ISO8601DateFormatter` with `.withInternetDateTime`, which always renders dates in UTC (with a `Z` suffix). Dates are parsed correctly in the user's local timezone by DateParser, but when displayed back, they appear shifted to UTC.
+
+**Example**: User creates event at `2026-02-22T14:30:00` (local PST). EventInfo outputs `2026-02-22T22:30:00Z` — the user sees a UTC timestamp instead of their local time, making the output confusing and incorrect from the user's perspective.
+
+The root cause is the static `formatter` in `EventInfo.swift` (line ~51-55):
+```swift
+private static nonisolated(unsafe) let formatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter
+}()
+```
+
+`ISO8601DateFormatter` with `.withInternetDateTime` always normalizes to UTC. There is no mechanism to preserve or output the local timezone.
+
+## Approach
+
+1. **Change the output formatter** in `EventInfo.swift` to use a `DateFormatter` with ISO8601 format that respects the local timezone (e.g., `2026-02-22T14:30:00-08:00`) instead of converting to UTC with `Z`.
+2. **Update the ISO8601 formatter** to include `.withTimeZone` and set `timeZone = .current` so output includes the local offset (e.g., `-08:00`) rather than `Z`.
+3. **Update unit tests** in `DateParserTests.swift` to verify round-trip timezone behavior: parse a local datetime string, format it back, and confirm the local time components are preserved.
+
+## Files to change
+
+- `Sources/apple-calendar-cli/Models/EventInfo.swift` (modify — change formatter to output local timezone offset instead of UTC)
+- `Tests/apple-calendar-cli-tests/DateParserTests.swift` (modify — add timezone round-trip tests)
+
+## Verification
+
+- Run: `swift test`
+- Expected: All tests pass, including new timezone round-trip tests
+- Manual check: `swift run apple-calendar-cli list-events --json` should output dates with local timezone offset (e.g., `-08:00`) instead of `Z`
+- Regression check: create-event and update-event still parse dates correctly; list-events output remains valid ISO8601
+
+## Progress
+- Milestones: 3 commits
+- Modified: Sources/apple-calendar-cli/Models/EventInfo.swift, Tests/apple-calendar-cli-tests/DateParserTests.swift
+- Verification: not yet run — run /esper:finish to verify and archive

--- a/.esper/plans/done/013-timezone-conversion.md
+++ b/.esper/plans/done/013-timezone-conversion.md
@@ -9,6 +9,7 @@ branch: fix/timezone-conversion
 created: 2026-02-22
 gh_issue: 3
 shipped_at: 2026-02-22
+pr: https://github.com/sichengchen/apple-calendar-cli/pull/4
 ---
 # fix: dates output as UTC instead of local timezone
 

--- a/.esper/plans/done/013-timezone-conversion.md
+++ b/.esper/plans/done/013-timezone-conversion.md
@@ -1,13 +1,14 @@
 ---
 id: 13
 title: fix: dates output as UTC instead of local timezone
-status: active
+status: done
 type: fix
 priority: 1
 phase: 001-mvp-crud-and-agent-skill
 branch: fix/timezone-conversion
 created: 2026-02-22
 gh_issue: 3
+shipped_at: 2026-02-22
 ---
 # fix: dates output as UTC instead of local timezone
 

--- a/Sources/apple-calendar-cli/Models/EventInfo.swift
+++ b/Sources/apple-calendar-cli/Models/EventInfo.swift
@@ -101,6 +101,7 @@ struct RecurrenceRuleInfo: Codable {
             if let date = end.endDate {
                 let formatter = ISO8601DateFormatter()
                 formatter.formatOptions = [.withInternetDateTime]
+                formatter.timeZone = .current
                 self.endDate = formatter.string(from: date)
                 self.occurrenceCount = nil
             } else {

--- a/Sources/apple-calendar-cli/Models/EventInfo.swift
+++ b/Sources/apple-calendar-cli/Models/EventInfo.swift
@@ -51,6 +51,7 @@ struct EventInfo: Codable {
     private static nonisolated(unsafe) let formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = .current
         return formatter
     }()
 

--- a/Tests/apple-calendar-cli-tests/DateParserTests.swift
+++ b/Tests/apple-calendar-cli-tests/DateParserTests.swift
@@ -33,6 +33,26 @@ final class DateParserTests: XCTestCase {
         XCTAssertNotNil(date)
     }
 
+    func testRoundTripPreservesLocalTime() {
+        // Parse a local datetime string
+        let input = "2026-02-22T14:30:00"
+        let date = DateParser.parse(input)
+        XCTAssertNotNil(date)
+
+        // Format it back using the same ISO8601 config as EventInfo (local timezone)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = .current
+        let output = formatter.string(from: date!)
+
+        // The output should start with the same date and time (local), not be shifted to UTC
+        XCTAssertTrue(output.hasPrefix("2026-02-22T14:30:00"), "Expected local time 14:30, got: \(output)")
+        // Should have a timezone offset, not Z (unless the local timezone happens to be UTC)
+        if TimeZone.current.secondsFromGMT() != 0 {
+            XCTAssertFalse(output.hasSuffix("Z"), "Expected local timezone offset, not Z: \(output)")
+        }
+    }
+
     func testParseInvalidReturnsNil() {
         XCTAssertNil(DateParser.parse("not-a-date"))
         XCTAssertNil(DateParser.parse(""))


### PR DESCRIPTION
## What
Date output in JSON mode always showed UTC timestamps with `Z` suffix instead of the user's local timezone offset. A user creating an event at `14:30 local` would see `22:30:00Z` in the output.

## Approach
Set `timeZone = .current` on both `ISO8601DateFormatter` instances in `EventInfo.swift` — the static formatter used for event start/end dates, and the inline formatter in `RecurrenceRuleInfo` for recurrence end dates. Output now includes local timezone offset (e.g., `2026-02-22T14:30:00-08:00`).

## Verification
- `swift test` — 12 tests pass, including new `testRoundTripPreservesLocalTime`
- `swift build` — compiles cleanly
- Manual: `list-events --json` outputs dates with local offset instead of `Z`

Plan 013
Closes #3